### PR TITLE
feat: a client which implements the protocol

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,11 @@ We expect clients to eventually give up and just retry *without* the header, ski
 This implies your application should have other concurrency limiting or queuing in place, if
 appropriate. This might just be the node event loop.
 
+There's a wrapper for `request-promise-native` available in `requestWorkerRuns`. This
+will attempt to locate a worker which isn't overloaded, and send the request to it.
+If the worker doesn't support this protocol, or a free worker cannot be found,
+then the request will be run anyway; the same as if `request` was used directly.
+
 
 ## Example
 

--- a/lib/client.ts
+++ b/lib/client.ts
@@ -1,0 +1,58 @@
+import { RequestPromiseOptions } from 'request-promise-native';
+import { RequiredUriUrl } from 'request';
+import * as requestPromiseNative from 'request-promise-native';
+import { StatusCodeError } from 'request-promise-native/errors';
+// eslint-disable-next-line @typescript-eslint/no-require-imports
+import sleep = require('sleep-promise');
+
+export type RequestArg = RequestPromiseOptions & RequiredUriUrl;
+
+// @VisibleForTesting
+export async function requestWorkerRunsWith(
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  request: (req: RequestArg) => Promise<any>,
+  req: RequestPromiseOptions & RequiredUriUrl,
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+): Promise<any> {
+  for (let triedBackends = 0; triedBackends < 10; ++triedBackends) {
+    try {
+      return await request({
+        ...req,
+        headers: { ...(req.headers || {}), 'If-Not-Overloaded': '1' },
+      });
+    } catch (e) {
+      // if the service informs us it is overloaded...
+      if (e instanceof StatusCodeError && 420 === e.statusCode) {
+        // "immediately" try again, hitting a different worker in the pool
+
+        // this is *not* a delay to wait for the service to become ready;
+        // this is an attempt to slightly jitter our requests to avoid
+        // weird "thundering herd" style problems
+
+        // for 5 retries,
+        // 10 * [0-4] * [0-1] is somewhere between 0 and 40ms
+        // max total sleep is 0+1+2+3+4 = 100ms
+        // event loop and sleep jitter (~10ms) is significantly higher than our sleep time
+        await sleep(10 * triedBackends * Math.random());
+        continue;
+      }
+      throw e;
+    }
+  }
+
+  // give in, and just call whatever service is unlucky enough to be picked
+  // it's probably already told us it's busy. Unlucky, service.
+  return request(req);
+}
+
+/** RPC to a worker service, in a way that takes advantage of our pooling of worker services.
+ *
+ * The service needs to support this operation to get any benefit, but this function is written
+ * such that it is still safe to use with any service.
+ */
+export async function requestWorkerRuns(
+  req: RequestArg,
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+): Promise<any> {
+  return requestWorkerRunsWith(requestPromiseNative, req);
+}

--- a/lib/index.ts
+++ b/lib/index.ts
@@ -1,1 +1,2 @@
 export { makeOverloadLimiter, Options } from './overload-limiter';
+export { requestWorkerRuns } from './client';

--- a/package.json
+++ b/package.json
@@ -13,7 +13,10 @@
   },
   "dependencies": {
     "on-finished": "^2.3.0",
-    "prom-client": "^11.5.3"
+    "prom-client": "^11.5.3",
+    "request": "^2.88.0",
+    "request-promise-native": "^1.0.8",
+    "sleep-promise": "^8.0.1"
   },
   "devDependencies": {
     "@types/express": "^4.17.2",
@@ -21,6 +24,8 @@
     "@types/needle": "^2.0.4",
     "@types/node": "^12.12.17",
     "@types/on-finished": "^2.3.1",
+    "@types/request": "^2.48.4",
+    "@types/request-promise-native": "^1.0.17",
     "@typescript-eslint/eslint-plugin": "^2.11.0",
     "@typescript-eslint/parser": "^2.11.0",
     "async-sema": "^3.0.1",

--- a/test/client.test.ts
+++ b/test/client.test.ts
@@ -1,0 +1,52 @@
+import { requestWorkerRunsWith, RequestArg } from '../lib/client';
+import { StatusCodeError } from 'request-promise-native/errors';
+
+const limitHeader = { 'If-Not-Overloaded': '1' };
+
+test('if the service does not support the protocol, the request is not re-sent', async () => {
+  const mockReq = {
+    url: 'http://potato',
+  };
+  const expectedReq = {
+    ...mockReq,
+    headers: limitHeader,
+  };
+  const seenReqs: RequestArg[] = [];
+  const result = await requestWorkerRunsWith(async (req) => {
+    seenReqs.push(req);
+    return seenReqs.length;
+  }, mockReq);
+
+  expect(result).toBe(1);
+  expect(seenReqs).toEqual([expectedReq]);
+});
+
+test('the service always rejects if it can', async () => {
+  const mockReq = {
+    url: 'http://potato',
+  };
+  const expectedReq = {
+    ...mockReq,
+    headers: limitHeader,
+  };
+  const seenReqs: RequestArg[] = [];
+  const result = await requestWorkerRunsWith(async (req) => {
+    seenReqs.push(req);
+    if ((req.headers || {})['If-Not-Overloaded'] === '1') {
+      throw new StatusCodeError(420, {}, req, undefined as any);
+    }
+    return seenReqs.length;
+  }, mockReq);
+
+  // we tried a few times, at least
+  expect(seenReqs.length).toBeGreaterThan(2);
+
+  // we returned the result of the final call
+  expect(result).toBe(seenReqs.length);
+
+  // all of the requests except the last have the header
+  for (let i = 0; i < seenReqs.length - 1; i++) {
+    expect(seenReqs[i]).toEqual(expectedReq);
+  }
+  expect(seenReqs[seenReqs.length - 1]).toEqual(mockReq);
+});


### PR DESCRIPTION
Let's move the code from https://github.com/snyk/registry/pull/10921 to here.

Outstanding negative reviews, and responses:

* The name of the function? I'm keen to keep it as it is; it is (logically) enqueuing a message onto our worker pool. It is not retrying anything; network errors, etc. It is not debouncing, and I don't think it should be.

* What's the number in the retry count? Can we get the actual number of workers? Yes, we can. But, we don't really care. We are trying to increase the probability of hitting an "available" worker, given that each request hits a random worker. If there are four workers, and one is currently not overloaded, our first request has a 75% "failure" chance. On retry gets us to a 56% overall "failure" rate (`.75^2`). By ten requests, we're at 5%. Note the maths is the same for 400 workers with 100 currently available; we don't need to issue 400 requests to succeed. Also remember that "failure" here means we just fall back to the old behaviour (of the worker having to handle the load).

* Why such a short, random sleep? Why sleep at all? We don't want to be a [thundering herd](https://en.wikipedia.org/wiki/Thundering_herd_problem). In general, it's good practice to introduce random delays into cold error paths like this one. It helps prevent weird ordering problems, where a bunch of uncoordinated things trigger at the same time, and hit some edge case in some other service. It is not necessary, but (imo) actually eases reasoning about the system.

* Why not sleep for longer? We are not a retry system. We are not waiting for autoscaling to happen on the other end. We are not trying to smooth out load in time, only in space. We are just trying to put a message in a worker, and giving up if we can't.