### PR TITLE
feat: switch out request for needle

### DIFF
--- a/lib/client.ts
+++ b/lib/client.ts
@@ -1,48 +1,57 @@
-import { RequestPromiseOptions } from 'request-promise-native';
-import { RequiredUriUrl } from 'request';
-import * as requestPromiseNative from 'request-promise-native';
-import { StatusCodeError } from 'request-promise-native/errors';
+import * as realNeedle from 'needle';
+import {
+  BodyData,
+  NeedleHttpVerbs,
+  NeedleOptions,
+  NeedleResponse,
+} from 'needle';
 // eslint-disable-next-line @typescript-eslint/no-require-imports
 import sleep = require('sleep-promise');
 
-export type RequestArg = RequestPromiseOptions & RequiredUriUrl;
+export type Needle = (
+  method: NeedleHttpVerbs,
+  url: string,
+  data: BodyData,
+  options?: NeedleOptions,
+) => Promise<NeedleResponse>;
 
 // @VisibleForTesting
-export async function requestWorkerRunsWith(
+export async function needleWorkerRunsWith(
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  request: (req: RequestArg) => Promise<any>,
-  req: RequestPromiseOptions & RequiredUriUrl,
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-): Promise<any> {
+  needle: Needle,
+  method: NeedleHttpVerbs,
+  url: string,
+  data: BodyData,
+  options?: NeedleOptions,
+): Promise<NeedleResponse> {
   for (let triedBackends = 0; triedBackends < 10; ++triedBackends) {
-    try {
-      return await request({
-        ...req,
-        headers: { ...(req.headers || {}), 'If-Not-Overloaded': '1' },
-      });
-    } catch (e) {
-      // if the service informs us it is overloaded...
-      if (e instanceof StatusCodeError && 420 === e.statusCode) {
-        // "immediately" try again, hitting a different worker in the pool
+    const response = await needle(method, url, data, {
+      ...options,
+      headers: { ...((options || {}).headers || {}), 'If-Not-Overloaded': '1' },
+    });
 
-        // this is *not* a delay to wait for the service to become ready;
-        // this is an attempt to slightly jitter our requests to avoid
-        // weird "thundering herd" style problems
-
-        // for 5 retries,
-        // 10 * [0-4] * [0-1] is somewhere between 0 and 40ms
-        // max total sleep is 0+1+2+3+4 = 100ms
-        // event loop and sleep jitter (~10ms) is significantly higher than our sleep time
-        await sleep(10 * triedBackends * Math.random());
-        continue;
-      }
-      throw e;
+    // for any status except our special "I'm overloaded!" status, immediately return.
+    // also, any errors are just thrown directly
+    if (420 !== response.statusCode) {
+      return response;
     }
+
+    // "immediately" try again, hitting a different worker in the pool
+
+    // this is *not* a delay to wait for the service to become ready;
+    // this is an attempt to slightly jitter our requests to avoid
+    // weird "thundering herd" style problems
+
+    // for 5 retries,
+    // 10 * [0-4] * [0-1] is somewhere between 0 and 40ms
+    // max total sleep is 0+1+2+3+4 = 100ms
+    // event loop and sleep jitter (~10ms) is significantly higher than our sleep time
+    await sleep(10 * triedBackends * Math.random());
   }
 
   // give in, and just call whatever service is unlucky enough to be picked
   // it's probably already told us it's busy. Unlucky, service.
-  return request(req);
+  return needle(method, url, data, options);
 }
 
 /** RPC to a worker service, in a way that takes advantage of our pooling of worker services.
@@ -50,9 +59,11 @@ export async function requestWorkerRunsWith(
  * The service needs to support this operation to get any benefit, but this function is written
  * such that it is still safe to use with any service.
  */
-export async function requestWorkerRuns(
-  req: RequestArg,
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-): Promise<any> {
-  return requestWorkerRunsWith(requestPromiseNative, req);
+export async function needleWorkerRuns(
+  method: NeedleHttpVerbs,
+  url: string,
+  data: BodyData,
+  options?: NeedleOptions,
+): Promise<NeedleResponse> {
+  return needleWorkerRunsWith(realNeedle, method, url, data, options);
 }

--- a/lib/index.ts
+++ b/lib/index.ts
@@ -1,2 +1,2 @@
 export { makeOverloadLimiter, Options } from './overload-limiter';
-export { requestWorkerRuns } from './client';
+export { needleWorkerRuns } from './client';

--- a/package.json
+++ b/package.json
@@ -12,10 +12,9 @@
     "format": "prettier --write 'lib/**/*.?s' 'test/**/*.?s'"
   },
   "dependencies": {
+    "needle": "^2.4.0",
     "on-finished": "^2.3.0",
     "prom-client": "^11.5.3",
-    "request": "^2.88.0",
-    "request-promise-native": "^1.0.8",
     "sleep-promise": "^8.0.1"
   },
   "devDependencies": {
@@ -24,8 +23,6 @@
     "@types/needle": "^2.0.4",
     "@types/node": "^12.12.17",
     "@types/on-finished": "^2.3.1",
-    "@types/request": "^2.48.4",
-    "@types/request-promise-native": "^1.0.17",
     "@typescript-eslint/eslint-plugin": "^2.11.0",
     "@typescript-eslint/parser": "^2.11.0",
     "async-sema": "^3.0.1",

--- a/test/client.test.ts
+++ b/test/client.test.ts
@@ -1,48 +1,51 @@
-import { requestWorkerRunsWith, RequestArg } from '../lib/client';
-import { StatusCodeError } from 'request-promise-native/errors';
+import { Needle, needleWorkerRunsWith } from '../lib/client';
+import {
+  BodyData,
+  NeedleHttpVerbs,
+  NeedleOptions,
+  NeedleResponse,
+} from 'needle';
 
 const limitHeader = { 'If-Not-Overloaded': '1' };
 
 test('if the service does not support the protocol, the request is not re-sent', async () => {
-  const mockReq = {
-    url: 'http://potato',
-  };
-  const expectedReq = {
-    ...mockReq,
-    headers: limitHeader,
-  };
-  const seenReqs: RequestArg[] = [];
-  const result = await requestWorkerRunsWith(async (req) => {
-    seenReqs.push(req);
-    return seenReqs.length;
-  }, mockReq);
+  const expectedReq = ['get', 'http://potato', {}, { headers: limitHeader }];
 
-  expect(result).toBe(1);
+  const seenReqs: any[] = [];
+  const result = await needleWorkerRunsWith(
+    mockNeedle(seenReqs, () => 200),
+    'get',
+    'http://potato',
+    {},
+  );
+
+  expect(result.statusCode).toBe(200);
+  expect(result.body).toBe(1);
   expect(seenReqs).toEqual([expectedReq]);
 });
 
 test('the service always rejects if it can', async () => {
-  const mockReq = {
-    url: 'http://potato',
-  };
-  const expectedReq = {
-    ...mockReq,
-    headers: limitHeader,
-  };
-  const seenReqs: RequestArg[] = [];
-  const result = await requestWorkerRunsWith(async (req) => {
-    seenReqs.push(req);
-    if ((req.headers || {})['If-Not-Overloaded'] === '1') {
-      throw new StatusCodeError(420, {}, req, undefined as any);
-    }
-    return seenReqs.length;
-  }, mockReq);
+  const mockReq = ['get', 'http://potato', {}, undefined];
+  const expectedReq = ['get', 'http://potato', {}, { headers: limitHeader }];
+
+  const seenReqs: any[] = [];
+  const result = await needleWorkerRunsWith(
+    mockNeedle(seenReqs, (options) => {
+      if (((options || {}).headers || {})['If-Not-Overloaded'] === '1') {
+        return 420;
+      }
+      return 200;
+    }),
+    'get',
+    'http://potato',
+    {},
+  );
 
   // we tried a few times, at least
   expect(seenReqs.length).toBeGreaterThan(2);
 
   // we returned the result of the final call
-  expect(result).toBe(seenReqs.length);
+  expect(result.body).toBe(seenReqs.length);
 
   // all of the requests except the last have the header
   for (let i = 0; i < seenReqs.length - 1; i++) {
@@ -50,3 +53,25 @@ test('the service always rejects if it can', async () => {
   }
   expect(seenReqs[seenReqs.length - 1]).toEqual(mockReq);
 });
+
+function mockNeedle(
+  seenReqs: any[],
+  handle: (options?: NeedleOptions) => number,
+): Needle {
+  return async (
+    method: NeedleHttpVerbs,
+    url: string,
+    data: BodyData,
+    options?: NeedleOptions,
+  ): Promise<NeedleResponse> => {
+    seenReqs.push([method, url, data, options]);
+    return mockResponse(handle(options), seenReqs.length);
+  };
+}
+
+function mockResponse(statusCode: number, body: any): NeedleResponse {
+  return {
+    body,
+    statusCode,
+  } as any;
+}


### PR DESCRIPTION
BREAKING CHANGE: request-based methods are gone, new needle-based methods exist

This only matters if you are using the client.

`request-promise-native` breaks `jest` in some of our services. SIGH.