### PR TITLE
feat: upgrade prom-client (requires node > 8)

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
   "dependencies": {
     "needle": "^2.4.0",
     "on-finished": "^2.3.0",
-    "prom-client": "^11.5.3",
+    "prom-client": "^12.0.0",
     "sleep-promise": "^8.0.1"
   },
   "devDependencies": {


### PR DESCRIPTION
Major version upgrades the min required version (we already require 10(?)), and changes the way the client is constructed (we don't do that).