### PR TITLE
feat: upgrade needle

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
   },
   "devDependencies": {
     "@types/express": "^4.17.2",
-    "@types/jest": "^24.0.23",
+    "@types/jest": "^25.2.3",
     "@types/needle": "^2.0.4",
     "@types/node": "^12.12.17",
     "@types/on-finished": "^2.3.1",
@@ -30,10 +30,10 @@
     "eslint-config-prettier": "^6.7.0",
     "eslint-plugin-jest": "^23.1.1",
     "express": "^4.17.1",
-    "jest": "^24.9.0",
+    "jest": "^26.0.1",
     "needle": "^2.5.0",
     "prettier": "^1.19.1",
-    "ts-jest": "^24.2.0",
+    "ts-jest": "^26.1.0",
     "typescript": "^3.7.3"
   },
   "repository": {

--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
     "format": "prettier --write 'lib/**/*.?s' 'test/**/*.?s'"
   },
   "dependencies": {
-    "needle": "^2.4.0",
+    "needle": "^2.5.0",
     "on-finished": "^2.3.0",
     "prom-client": "^12.0.0",
     "sleep-promise": "^8.0.1"
@@ -31,7 +31,7 @@
     "eslint-plugin-jest": "^23.1.1",
     "express": "^4.17.1",
     "jest": "^24.9.0",
-    "needle": "^2.4.0",
+    "needle": "^2.5.0",
     "prettier": "^1.19.1",
     "ts-jest": "^24.2.0",
     "typescript": "^3.7.3"


### PR DESCRIPTION
needle has a bug with sockets on newer node 12,
we're currently avoiding this newer node 12 to
evade the problem. This bug is fixed in needle
2.5.0, so let's upgrade to that.

tomas/needle#312