### PR TITLE
feat: move prom-client to a peer dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,7 +14,6 @@
   "dependencies": {
     "needle": "^2.5.0",
     "on-finished": "^2.3.0",
-    "prom-client": "^12.0.0",
     "sleep-promise": "^8.0.1"
   },
   "devDependencies": {
@@ -31,10 +30,13 @@
     "eslint-plugin-jest": "^23.1.1",
     "express": "^4.17.1",
     "jest": "^26.0.1",
-    "needle": "^2.5.0",
     "prettier": "^1.19.1",
+    "prom-client": "^13.1.0",
     "ts-jest": "^26.1.0",
     "typescript": "^3.7.3"
+  },
+  "peerDependencies": {
+    "prom-client": "12 || 13"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
Loosen our dependency on `prom-client`.

Arguably a breaking change? I think both of the users are "broken" now (as in, they incorrectly load a different prom-client for this library and for themselves), so this is more of a fix than a breaking change.